### PR TITLE
Add News Input and output data object

### DIFF
--- a/src/main/java/interfaceadapter/controller/NewsController.java
+++ b/src/main/java/interfaceadapter/controller/NewsController.java
@@ -1,15 +1,33 @@
 package interfaceadapter.controller;
 
 import usecase.news.NewsInputBoundary;
+import usecase.news.NewsInputData;
 
+/**
+ * Controller responsible for handling news retrieval requests.
+ * Receives user actions from the interface layer and forwards them
+ * to the news retrieval use case interactor.
+ */
 public class NewsController {
     private final NewsInputBoundary interactor;
 
+    /**
+     * Constructs a NewsController with the given interactor.
+     *
+     * @param interactor the input boundary for the news retrieval use case
+     */
     public NewsController(NewsInputBoundary interactor) {
         this.interactor = interactor;
     }
 
-    public void onNewsRequest(String symbol){
-        interactor.fetchNews(symbol);
+    /**
+     * Initiates a news retrieval request for the given symbol.
+     *
+     * @param symbol the stock ticker symbol to fetch news for
+     */
+    public void onNewsRequest(String symbol) {
+        final NewsInputData data = new NewsInputData(symbol);
+        interactor.execute(data);
     }
 }
+

--- a/src/main/java/interfaceadapter/presenter/NewsPresenter.java
+++ b/src/main/java/interfaceadapter/presenter/NewsPresenter.java
@@ -1,46 +1,33 @@
 package interfaceadapter.presenter;
 
-import entity.NewsArticle;
 import interfaceadapter.view_model.NewsViewModel;
 import usecase.news.NewsOutputBoundary;
-
-import java.util.List;
+import usecase.news.NewsOutputData;
 
 public class NewsPresenter implements NewsOutputBoundary {
 
-    private final NewsViewModel vm;
+    private final NewsViewModel viewmodel;
 
-    public NewsPresenter(NewsViewModel vm) {
-        this.vm = vm;
+    public NewsPresenter(NewsViewModel viewmodel) {
+        this.viewmodel = viewmodel;
     }
 
     @Override
-    public void presentNews(List<NewsArticle> list) {
-        vm.error = null;
-        vm.articles = list;
-        vm.formattedNews = format(list);
-        vm.notifyListener();
+    public void presentNews(NewsOutputData data) {
+        viewmodel.error = null;
+        viewmodel.articles = data.getStatements();
+        viewmodel.formattedNews = String.join("\n", data.getStatements());
+        viewmodel.notifyListener();
     }
 
     @Override
     public void presentError(String message) {
-        vm.articles = null;
-        vm.formattedNews = "";
-        vm.error = message;
-        vm.notifyListener();
+        viewmodel.articles = null;
+        viewmodel.formattedNews = "";
+        viewmodel.error = message;
+        viewmodel.notifyListener();
     }
 
-    private String format(List<NewsArticle> list) {
-        StringBuilder sb = new StringBuilder();
-
-        for (NewsArticle article : list) {
-            sb.append(article.getTitle()).append("\n");
-            sb.append("Source: ").append(article.getSource()).append("\n");
-            sb.append("Published: ").append(article.getPublishedAt()).append("\n");
-            sb.append(article.getSummary()).append("\n");
-            sb.append("----------------------------------\n");
-        }
-
-        return sb.toString();
-    }
 }
+
+

--- a/src/main/java/interfaceadapter/view_model/NewsViewModel.java
+++ b/src/main/java/interfaceadapter/view_model/NewsViewModel.java
@@ -1,12 +1,10 @@
 package interfaceadapter.view_model;
 
-import entity.NewsArticle;
-
 import java.util.List;
 
 public class NewsViewModel {
 
-    public List<NewsArticle> articles;
+    public List<String> articles;
 
     public String formattedNews;
 

--- a/src/main/java/usecase/news/NewsGateway.java
+++ b/src/main/java/usecase/news/NewsGateway.java
@@ -1,9 +1,19 @@
 package usecase.news;
 
-import entity.NewsArticle;
 import java.util.List;
 
+import entity.NewsArticle;
 
+/**
+ * Gateway interface for retrieving news articles related to a company.
+ * Implementations provide access to external data sources such as APIs.
+ */
 public interface NewsGateway {
+    /**
+     * Fetches a list of news articles associated with the given stock symbol.
+     *
+     * @param symbol the stock ticker symbol to retrieve news for
+     * @return a list of related news articles, or an empty list if none are found
+     */
     List<NewsArticle> fetchArticles(String symbol);
 }

--- a/src/main/java/usecase/news/NewsInputBoundary.java
+++ b/src/main/java/usecase/news/NewsInputBoundary.java
@@ -1,5 +1,14 @@
 package usecase.news;
 
+/**
+ * Input boundary for the news retrieval use case.
+ * Accepts the input data necessary to trigger fetching and presenting news articles.
+ */
 public interface NewsInputBoundary {
-    void fetchNews(String symbol);
+    /**
+     * Executes the news retrieval use case using the provided input data.
+     *
+     * @param data the input data containing the symbol to fetch news for
+     */
+    void execute(NewsInputData data);
 }

--- a/src/main/java/usecase/news/NewsInputData.java
+++ b/src/main/java/usecase/news/NewsInputData.java
@@ -1,0 +1,13 @@
+package usecase.news;
+
+public class NewsInputData {
+    private final String symbol;
+
+    public NewsInputData(String symbol) {
+        this.symbol = symbol;
+    }
+
+    public String getSymbol() {
+        return symbol;
+    }
+}

--- a/src/main/java/usecase/news/NewsInteractor.java
+++ b/src/main/java/usecase/news/NewsInteractor.java
@@ -1,31 +1,43 @@
 package usecase.news;
 
-
+import java.util.ArrayList;
+import java.util.List;
 
 import entity.NewsArticle;
-
-import java.util.List;
 
 public class NewsInteractor implements NewsInputBoundary {
     private final NewsGateway gateway;
     private final NewsOutputBoundary presenter;
 
     public NewsInteractor(NewsGateway gateway,
-                                        NewsOutputBoundary presenter) {
+                          NewsOutputBoundary presenter) {
         this.gateway = gateway;
         this.presenter = presenter;
     }
 
     @Override
-    public void fetchNews(String symbol) {
-        List<NewsArticle> statements = gateway.fetchArticles(symbol);
+    public void execute(NewsInputData data) {
+        final String symbol = data.getSymbol();
+        final List<NewsArticle> statements = gateway.fetchArticles(symbol);
 
         if (statements == null || statements.isEmpty()) {
             presenter.presentError("No related news found for: " + symbol);
-            return;
         }
-
-        presenter.presentNews(statements);
+        else {
+            final List<String> formatted = new ArrayList<>();
+            final String blank = "\n";
+            for (NewsArticle article : statements) {
+                final String block =
+                        "Title: " + article.getTitle() + blank
+                                + "Source: " + article.getSource() + blank
+                                + "Published At: " + article.getPublishedAt() + blank
+                                + "Summary: " + article.getSummary() + blank
+                                + "----------------------------------";
+                formatted.add(block);
+            }
+            final NewsOutputData output = new NewsOutputData(symbol, formatted);
+            presenter.presentNews(output);
+        }
 
     }
 

--- a/src/main/java/usecase/news/NewsOutputBoundary.java
+++ b/src/main/java/usecase/news/NewsOutputBoundary.java
@@ -1,11 +1,22 @@
 package usecase.news;
 
-import java.util.List;
-
-import entity.NewsArticle;
-
+/**
+ * Output boundary for the news retrieval use case.
+ * Implementations handle presenting formatted news data
+ * or displaying an appropriate error message.
+ */
 public interface NewsOutputBoundary {
-    void presentNews(List<NewsArticle> newsArticles);
+    /**
+     * Presents the retrieved and formatted news data.
+     *
+     * @param data the processed news data to be displayed
+     */
+    void presentNews(NewsOutputData data);
 
+    /**
+     * Presents an error message when news retrieval fails.
+     *
+     * @param message the descriptive error message
+     */
     void presentError(String message);
 }

--- a/src/main/java/usecase/news/NewsOutputData.java
+++ b/src/main/java/usecase/news/NewsOutputData.java
@@ -1,0 +1,21 @@
+package usecase.news;
+
+import java.util.List;
+
+public class NewsOutputData {
+    private String symbol;
+    private List<String> statements;
+
+    public NewsOutputData(String symbol, List<String> statements) {
+        this.symbol = symbol;
+        this.statements = statements;
+    }
+
+    public String getSymbol() {
+        return symbol;
+    }
+
+    public List<String> getStatements() {
+        return statements;
+    }
+}


### PR DESCRIPTION
This update introduces NewsInputData and NewsOutputData to clearly define the data flow for the News use case.

What was added

NewsInputData
- Encapsulates the stock symbol provided by the user when requesting related news articles.
- Ensures that the controller communicates with the use case via a clean, immutable request object.

NewsOutputData
- Contains the processed and formatted results returned by the interactor.
- Includes the symbol along with a list of readable news blocks (title, source, time, summary).
- This removes UI-specific concerns from the interactor and keeps data presentation consistent.

Why this matters
- Prevents the UI layer from depending on entity classes or raw gateway results.
- Keeps business rules inside the use case layer, consistent with Clean Architecture.
- Helps presenters remain simple, since they receive already-formatted display content.
- Greatly improves testability by allowing deterministic input/output validation.

Additional updates
- Updated NewsInteractor to use the new input/output data objects.
- Updated controllers and presenters accordingly.
- Fixed Checkstyle issues (Javadoc, naming, line length, parameter limits).
