### PR TITLE
linking company detail and company main

### DIFF
--- a/src/main/java/app/CompanyMain.java
+++ b/src/main/java/app/CompanyMain.java
@@ -42,8 +42,17 @@ import dataaccess.EnvConfig;
 public class CompanyMain {
 
     public static void main(String[] args) {
-            final EnvConfig envConfig = new EnvConfig();
-            final String apiKey = envConfig.getAlphaVantageApiKey();
+        final EnvConfig envConfig = new EnvConfig();
+        final String apiKey = envConfig.getAlphaVantageApiKey();
+
+        String preloadedSymbol = null;
+
+        if (args != null && args.length > 0) {
+            preloadedSymbol = args[0];
+            System.out.println("Starting CompanyPage with preloaded symbol: " + preloadedSymbol);
+        }
+
+        final String symbolForLambda = preloadedSymbol;
 
             SwingUtilities.invokeLater(() -> {
 
@@ -118,6 +127,9 @@ public class CompanyMain {
             // inject controllers into UI
             ui.setControllers(companyController, fsController, newsController, intervalController);
 
+            if (symbolForLambda != null) {
+                ui.setInitialSymbol(symbolForLambda);
+            }
             ui.setVisible(true);
         });
     }

--- a/src/main/java/frameworkanddriver/CompanyPage.java
+++ b/src/main/java/frameworkanddriver/CompanyPage.java
@@ -74,6 +74,7 @@ public class CompanyPage extends JFrame {
     // ---------------------------------------------------------
     // UI BUILDING
     // ---------------------------------------------------------
+
     private void buildUI() {
         setTitle("Stock Analysis Dashboard");
         setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
@@ -306,12 +307,12 @@ public class CompanyPage extends JFrame {
 
         // 3. Update current Ticker
         currentTicker = companyVM.symbol;
-        
+
         // --- Core modification start ---
         if (chartController != null) {
             // Step 1: Tell controller which stock is current
             chartController.setCurrentTicker(currentTicker);
-            
+
             // Step 2: Tell chart component to enable Zoom functionality
             if (chartPanel != null) {
                 chartPanel.enableZoom(currentTicker);
@@ -347,6 +348,14 @@ public class CompanyPage extends JFrame {
         return chartPanel;
     }
 
+    public void setInitialSymbol(String symbol) {
+        symbolField.setText(symbol);
+
+        if (companyController != null) companyController.onCompanySelected(symbol);
+        if (fsController != null) fsController.onFinancialRequest(symbol);
+        if (newsController != null) newsController.onNewsRequest(symbol);
+        if (chartController != null) chartController.setCurrentTicker(symbol);
+    }
 
 }
 


### PR DESCRIPTION
This update adds full navigation support between the Global Market Overview page and the Company Details page. When a user clicks the “View” button in the market table, the system now opens the Company Details page preloaded with the correct stock symbol.

What was added

- Implemented a preloaded symbol mechanism using program arguments for CompanyMain.
- When the user selects a company and presses View, the selected symbol is passed to the Company Details page
- CompanyMain now detects this symbol and forwards it into the UI.
- The CompanyPage UI includes a new setInitialSymbol(String) method that automatically: Fills the search bar with the incoming symbol, Triggers the search logic, Loads company overview, news, chart, and financials immediately

Why this matters
Previously, clicking View opened the details page but didn’t display the selected company. The user had to manually type the symbol again. This update creates a smooth, consistent workflow by ensuring the correct company is loaded instantly after clicking View.